### PR TITLE
Fix #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ stop on shutdown
 respawn
 respawn limit 99 5
 
+console log
+
 script
-    exec bugsnag-agent 2>&1 1>/var/log/bugsnag.log
+    exec bugsnag-agent
 end script
 ```
 


### PR DESCRIPTION
The shell redirection to `/var/log/bugsnag.log` wasn't working for some reason, but the `console log` Upstart stanza seems to be a builtin way to have your daemon's output sent to a log file (namely `/var/log/upstart/bugsnag.log`) and it works.