### PR TITLE
Better error handling for requests to Bugsnag

### DIFF
--- a/bin/bugsnag-agent
+++ b/bin/bugsnag-agent
@@ -176,13 +176,20 @@ class BugsnagAgent(object):
 
             try:
                 req = urllib2.Request(self.endpoint, body)
-                urllib2.urlopen(req).read()
-            except:
-                logger.info('Cannot send request. Retrying in 5 seconds')
-                print_exception(*sys.exc_info())
-                logger.info('Continuing...')
-                self.enqueue(body)
-                sleep(5)
+                res = urllib2.urlopen(req)
+                res.read()
+            except urllib2.URLError as e:
+                if hasattr(e, 'code') and 400 <= e.code < 500:
+                    logger.warning('Bad response, removing report ({code}: {msg})'.format(
+                        code=e.code,
+                        msg=e.msg
+                    ))
+                else:
+                    logger.warning('Cannot send request. Retrying in 5 seconds')
+                    if logger.isEnabledFor(logging.DEBUG):
+                        print_exception(*sys.exc_info())
+                    sleep(5)
+                    self.enqueue(body)
 
     def _thread(self, target):
         def run():


### PR DESCRIPTION
I was having problems with big reports throwing the agent into an endless loop trying to send the same report over and over again. Since there was no delay this continued until someone restarted the agent, creating huge network spikes.

This commit solved two problems:

Remove report for client errors (4xx):
Actually I see now in the docs that a 408 could be return (on timeout), so perhaps the removal of the report should only happen on a 400 status.

Also sleep for 5 sec **before** enqueuing  (useless otherwise because of threading)

