### PR TITLE
Added support for CORS while running on a different host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.2.1
+
+### Enhancements
+
+* Added support for CORS for agents running in different host
+  [#20](https://github.com/bugsnag/bugsnag-agent/pull/20)
+
 ## 1.2.0
 
 ### Enhancements

--- a/bugsnag_agent/__init__.py
+++ b/bugsnag_agent/__init__.py
@@ -213,6 +213,16 @@ class BugsnagAgent(object):
 
 class BugsnagHTTPRequestHandler(BaseHTTPRequestHandler):
 
+    def do_OPTIONS(self):
+        """
+        Enable CORS while running on a different host
+        """
+        self.send_response(200, "ok")
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Methods', 'GET, OPTIONS, POST, HEAD')
+        self.send_header("Access-Control-Allow-Headers", "*")
+        self.end_headers()
+
     def do_GET(self):
         """
         Show the current status of the agent

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='bugsnag-agent',
-    version='1.2.0',
+    version='1.2.1',
     description='A forwarding agent for Bugsnag to minimize reporting impact',
     long_description=__doc__,
     url='https://github.com/bugsnag/bugsnag-agent',


### PR DESCRIPTION
## Goal

Fixed  [#19](https://github.com/bugsnag/bugsnag-agent/issues/19) - Cross Origin Resource Request error when the agent is running on a different host.

## Design

Implemented ```HTTP OPTIONS``` method handler with relevant ``Access-Control-Allow-Origin headers`` to support CORS.

## Changeset

### Added

New function to handle ```OPTIONS``` method.

## Tests

Manually tested & verified by running the agent in a remote host.

## Discussion

### Linked issues

Issue [#19](https://github.com/bugsnag/bugsnag-agent/issues/19)

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [x] Consistency across platforms for structures or concepts added or modified
- [x] Consistency between the changeset and the goal stated above
- [x] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [x] Usage friction - is the proposed change in usage cumbersome or complicated?
- [x] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [x] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [x] Thoroughness of added tests and any missing edge cases
- [x] Idiomatic use of the language
