### PR TITLE
Add license auditing to CI

### DIFF
--- a/.github/workflows/license-audit.yml
+++ b/.github/workflows/license-audit.yml
@@ -1,0 +1,34 @@
+name: Audit bugsnag-agent dependency licenses
+
+on: [push, pull_request]
+
+jobs:
+  license-audit:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 2.7
+
+    - name: Fetch decisions.yml
+      run: curl https://raw.githubusercontent.com/bugsnag/license-audit/master/config/decision_files/global.yml -o decisions.yml
+
+    # License Finder doesn't use "install_requires" from setup.py, so won't check
+    # our dependencies if we don't put them in a requirements.txt file
+    - name: Set up requirements.txt for License Finder
+      run: |
+        pip install .
+        pip freeze --local | tee requirements.txt
+
+    - name: Run License Finder
+      # for some reason license finder doesn't run without a login shell (-l)
+      run: >
+        docker run -v $PWD:/scan licensefinder/license_finder /bin/bash -lc "
+          cd /scan &&
+          pip install -r requirements.txt --quiet &&
+          license_finder --decisions-file decisions.yml --python-version 2
+        "


### PR DESCRIPTION
## Goal

Adds license auditing to CI; currently there are no dependencies to check, but [this run proves](https://github.com/bugsnag/bugsnag-agent/runs/2408428073) it works

This is mostly a copy paste from https://github.com/bugsnag/bugsnag-python/pull/256