### PR TITLE
Support python 2 and 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ on-premise Bugsnag installation. It's used to avoid any latency impact that
 might occur if you need to make a call over the network in every exception
 handler.
 
-:warning: Please note that `bugsnag-agent` is compatible with Python 2.6-2.7 and 3.x
-
 ## Getting started
 
 First you need to install the `bugsnag-agent` binary, and make it executable on your server:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ on-premise Bugsnag installation. It's used to avoid any latency impact that
 might occur if you need to make a call over the network in every exception
 handler.
 
-:warning: Please note that `bugsnag-agent` is compatible with Python 2.6-2.7
+:warning: Please note that `bugsnag-agent` is compatible with Python 2.6-2.7 and 3.x
 
 ## Getting started
 

--- a/bugsnag_agent/__init__.py
+++ b/bugsnag_agent/__init__.py
@@ -1,24 +1,20 @@
 import sys
+
 if sys.version_info[0] == 3:
-    import urllib
-    from argparse import ArgumentParser
     from http.server import BaseHTTPRequestHandler, HTTPServer
     from configparser import RawConfigParser
     from queue import Queue
     from _thread import interrupt_main
-    from urllib.request import Request as url_request
-    from urllib.request import urlopen as url_open
-    from urllib.error import URLError as url_error
+    from urllib.request import Request, urlopen
+    from urllib.error import URLError
 else:
-    import urllib2 as urllib
-    from argparse import ArgumentParser
     from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
     from ConfigParser import RawConfigParser
     from Queue import Queue
     from thread import interrupt_main
-    from urllib2 import Request as url_request
-    from urllib2 import urlopen as url_open
-    from urllib2 import URLError as url_error
+    from urllib2 import Request, urlopen, URLError
+
+from argparse import ArgumentParser
 from threading import Thread
 from time import sleep
 from traceback import print_exception
@@ -198,10 +194,10 @@ class BugsnagAgent(object):
             )
 
             try:
-                req = url_request(self.endpoint, body, headers)
-                res = url_open(req)
+                req = Request(self.endpoint, body, headers)
+                res = urlopen(req)
                 res.read()
-            except url_error as e:
+            except URLError as e:
                 if hasattr(e, 'code') and e.code in (400, 500):
                     logger.warning('Bad response, removing report ({code}: {msg})'.format(
                         code=e.code,

--- a/bugsnag_agent/__init__.py
+++ b/bugsnag_agent/__init__.py
@@ -198,7 +198,7 @@ class BugsnagAgent(object):
                     if logger.isEnabledFor(logging.DEBUG):
                         print_exception(*sys.exc_info())
                     sleep(5)
-                    self.enqueue(body)
+                    self.enqueue(body=body, headers=headers)
 
     def _thread(self, target):
         def run():

--- a/bugsnag_agent/__init__.py
+++ b/bugsnag_agent/__init__.py
@@ -1,10 +1,24 @@
 import sys
-import urllib2
-from argparse import ArgumentParser
-from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
-from ConfigParser import RawConfigParser
-from Queue import Queue
-from thread import interrupt_main
+if sys.version_info[0] == 3:
+    import urllib
+    from argparse import ArgumentParser
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+    from configparser import RawConfigParser
+    from queue import Queue
+    from _thread import interrupt_main
+    from urllib.request import Request as url_request
+    from urllib.request import urlopen as url_open
+    from urllib.error import URLError as url_error
+else:
+    import urllib2 as urllib
+    from argparse import ArgumentParser
+    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+    from ConfigParser import RawConfigParser
+    from Queue import Queue
+    from thread import interrupt_main
+    from urllib2 import Request as url_request
+    from urllib2 import urlopen as url_open
+    from urllib2 import URLError as url_error
 from threading import Thread
 from time import sleep
 from traceback import print_exception
@@ -99,7 +113,7 @@ class BugsnagAgent(object):
                      "listen": config.get,
                      "log_level": config.get,
                      "ip": config.get}
-        for opt, _ in vars(args).iteritems():
+        for opt, _ in vars(args).items():
             if getattr(args, opt) is not None:
                 setattr(self, opt, getattr(args, opt))
             elif config.has_option('bugsnag', opt) and opt in conf_opts:
@@ -184,10 +198,10 @@ class BugsnagAgent(object):
             )
 
             try:
-                req = urllib2.Request(self.endpoint, body, headers)
-                res = urllib2.urlopen(req)
+                req = url_request(self.endpoint, body, headers)
+                res = url_open(req)
                 res.read()
-            except urllib2.URLError as e:
+            except url_error as e:
                 if hasattr(e, 'code') and e.code in (400, 500):
                     logger.warning('Bad response, removing report ({code}: {msg})'.format(
                         code=e.code,
@@ -268,7 +282,7 @@ class BugsnagHTTPRequestHandler(BaseHTTPRequestHandler):
             self.send_header('Access-Control-Allow-Origin', '*')
             self.send_header('Content-Length', len(response))
             self.end_headers()
-            self.wfile.write(response)
+            self.wfile.write(response.encode())
         except:
             logger.info('Client disconnected before waiting for response')
             print_exception(*sys.exc_info())

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
         'Topic :: Software Development'
     ]
 )


### PR DESCRIPTION
## Goal

Support both python version 2 and 3.

## Design

This seems to be the simplest way of support both versions. There are other ways, but this felt good. 

## Changeset

* Minor fix for missing headers if an error occurs
* Support both python 2 and 3
* Add info about python 3 support

## Testing

Did some curl based tests with versions `2.7.18` and `3.8.10`